### PR TITLE
bin/json-validator: switch to jsonschema

### DIFF
--- a/bin/json-validator
+++ b/bin/json-validator
@@ -4,7 +4,8 @@
 import argparse
 import json
 import traceback
-import cerberus
+
+from jsonschema import validate
 
 
 # define some global variables
@@ -51,11 +52,11 @@ def main():
             print("ERROR: Could not load a valid JSON schema file from %s" % (t_global.args.schema_file))
             return(2)
 
-        v = cerberus.Validator()
-        if v.validate(json_contents, schema_contents):
-            return(0)
-        else:
-            print(v.errors)
+        try:
+            validate(instance=json_contents, schema=schema_contents)
+        except:
+            print("EXCEPTION: %s" % traceback.format_exc())
+            print("ERROR: JSON validation failed for %s using schema %s" % (t_global.args.json_file, t_global.args.schema_file))
             return(3)
             
 

--- a/workshop.json
+++ b/workshop.json
@@ -9,14 +9,14 @@
 	    "name": "default",
 	    "requirements": [
 		"python36",
-		"cerberus_pip"
+		"jsonschema_pip3"
 	    ]
 	},
 	{
 	    "name": "fedora31",
 	    "requirements": [
 		"python36",
-		"cerberus"
+		"python3-jsonschema"
 	    ]
 	}
     ],
@@ -31,20 +31,20 @@
 	    }
 	},
 	{
-	    "name": "cerberus_pip",
+	    "name": "jsconschema_pip3",
 	    "type": "manual",
 	    "manual_info": {
 		"commands": [
-		    "pip3 install cerberus"
+		    "pip3 install jsonschema"
 		]
 	    }
 	},
 	{
-	    "name": "cerberus",
+	    "name": "python3-jsonschema",
 	    "type": "distro",
 	    "distro_info": {
 		"packages": [
-		    "python3-cerberus"
+		    "python3-jsonschema"
 		]
 	    }
 	}


### PR DESCRIPTION
- Switch from Cerberus to JSON Schema draft 7 using jsonschema

- Cerberus is Python only while JSON Schema has broad language support
  allowing us to use a consistent schema across
  languages/projects/scripts.